### PR TITLE
chore(logs): delete unused logs

### DIFF
--- a/eagleye_rt/src/angular_velocity_offset_stop_node.cpp
+++ b/eagleye_rt/src/angular_velocity_offset_stop_node.cpp
@@ -80,11 +80,6 @@ int main(int argc, char** argv)
     angular_velocity_offset_stop_parameter.estimated_interval = conf["/**"]["ros__parameters"]["angular_velocity_offset_stop"]["estimated_interval"].as<double>();
     angular_velocity_offset_stop_parameter.outlier_threshold = conf["/**"]["ros__parameters"]["angular_velocity_offset_stop"]["outlier_threshold"].as<double>();
 
-    std::cout << "subscribe_twist_topic_name " << subscribe_twist_topic_name << std::endl;
-    std::cout << "imu_rate " << angular_velocity_offset_stop_parameter.imu_rate << std::endl;
-    std::cout << "stop_judgment_threshold " << angular_velocity_offset_stop_parameter.stop_judgment_threshold << std::endl;
-    std::cout << "estimated_minimum_interval " << angular_velocity_offset_stop_parameter.estimated_interval << std::endl;
-    std::cout << "outlier_threshold " << angular_velocity_offset_stop_parameter.outlier_threshold << std::endl;
   }
   catch (YAML::Exception& e)
   {

--- a/eagleye_rt/src/enable_additional_rolling_node.cpp
+++ b/eagleye_rt/src/enable_additional_rolling_node.cpp
@@ -144,15 +144,6 @@ int main(int argc, char** argv)
     _rolling_parameter.sync_judgment_threshold = conf["/**"]["ros__parameters"]["enable_additional_rolling"]["sync_judgment_threshold"].as<double>();
     _rolling_parameter.sync_search_period = conf["/**"]["ros__parameters"]["enable_additional_rolling"]["sync_search_period"].as<double>();
 
-    std::cout<< "subscribe_localization_pose_topic_name " << subscribe_localization_pose_topic_name << std::endl;
-
-    std::cout << "imu_rate " << _rolling_parameter.imu_rate << std::endl;
-    std::cout << "stop_judgment_threshold " << _rolling_parameter.stop_judgment_threshold << std::endl;
-
-    std::cout << "update_distance " << _rolling_parameter.update_distance << std::endl;
-    std::cout << "moving_average_time " << _rolling_parameter.moving_average_time << std::endl;
-    std::cout << "sync_judgment_threshold " << _rolling_parameter.sync_judgment_threshold << std::endl;
-    std::cout << "sync_search_period " << _rolling_parameter.sync_search_period << std::endl;
   }
   catch (YAML::Exception& e)
   {

--- a/eagleye_rt/src/heading_interpolate_node.cpp
+++ b/eagleye_rt/src/heading_interpolate_node.cpp
@@ -109,10 +109,6 @@ int main(int argc, char** argv)
     heading_interpolate_parameter.sync_search_period = conf["/**"]["ros__parameters"]["heading_interpolate"]["sync_search_period"].as<double>();
     heading_interpolate_parameter.proc_noise = conf["/**"]["ros__parameters"]["heading_interpolate"]["proc_noise"].as<double>();
 
-    std::cout << "imu_rate " << heading_interpolate_parameter.imu_rate << std::endl;
-    std::cout << "stop_judgment_threshold " << heading_interpolate_parameter.stop_judgment_threshold << std::endl;
-    std::cout << "sync_search_period " << heading_interpolate_parameter.sync_search_period << std::endl;
-    std::cout << "proc_noise " << heading_interpolate_parameter.proc_noise << std::endl;
   }
   catch (YAML::Exception& e)
   {

--- a/eagleye_rt/src/heading_node.cpp
+++ b/eagleye_rt/src/heading_node.cpp
@@ -188,23 +188,6 @@ int main(int argc, char** argv)
     heading_parameter.curve_judgment_threshold = conf["/**"]["ros__parameters"]["heading"]["curve_judgment_threshold"].as<double>();
     heading_parameter.init_STD = conf["/**"]["ros__parameters"]["heading"]["init_STD"].as<double>();
 
-    std::cout<< "use_gnss_mode " << use_gnss_mode << std::endl;
-
-    std::cout<< "subscribe_rtklib_nav_topic_name " << subscribe_rtklib_nav_topic_name << std::endl;
-    std::cout<< "subscribe_rmc_topic_name " << subscribe_rmc_topic_name << std::endl;
-
-    std::cout << "imu_rate " << heading_parameter.imu_rate << std::endl;
-    std::cout << "gnss_rate " << heading_parameter.gnss_rate << std::endl;
-    std::cout << "stop_judgment_threshold " << heading_parameter.stop_judgment_threshold << std::endl;
-    std::cout << "moving_judgment_threshold " << heading_parameter.moving_judgment_threshold << std::endl;
-
-    std::cout << "estimated_minimum_interval " << heading_parameter.estimated_minimum_interval << std::endl;
-    std::cout << "estimated_maximum_interval " << heading_parameter.estimated_maximum_interval << std::endl;
-    std::cout << "gnss_receiving_threshold " << heading_parameter.gnss_receiving_threshold << std::endl;
-    std::cout << "outlier_threshold " << heading_parameter.outlier_threshold << std::endl;
-    std::cout << "outlier_ratio_threshold " << heading_parameter.outlier_ratio_threshold << std::endl;
-    std::cout << "curve_judgment_threshold " << heading_parameter.curve_judgment_threshold << std::endl;
-    std::cout << "init_STD " << heading_parameter.init_STD << std::endl;
   }
   catch (YAML::Exception& e)
   {

--- a/eagleye_rt/src/height_node.cpp
+++ b/eagleye_rt/src/height_node.cpp
@@ -130,17 +130,6 @@ int main(int argc, char** argv)
     height_parameter.outlier_ratio_threshold = conf["/**"]["ros__parameters"]["height"]["outlier_ratio_threshold"].as<double>();
     height_parameter.moving_average_time = conf["/**"]["ros__parameters"]["height"]["moving_average_time"].as<double>();
 
-    std::cout << "imu_rate " << height_parameter.imu_rate << std::endl;
-    std::cout << "gnss_rate " << height_parameter.gnss_rate << std::endl;
-    std::cout << "moving_judgment_threshold " << height_parameter.moving_judgment_threshold << std::endl;
-
-    std::cout << "estimated_minimum_interval " << height_parameter.estimated_minimum_interval << std::endl;
-    std::cout << "estimated_maximum_interval " << height_parameter.estimated_maximum_interval << std::endl;
-    std::cout << "update_distance " << height_parameter.update_distance << std::endl;
-    std::cout << "gnss_receiving_threshold " << height_parameter.gnss_receiving_threshold << std::endl;
-    std::cout << "outlier_threshold " << height_parameter.outlier_threshold << std::endl;
-    std::cout << "outlier_ratio_threshold " << height_parameter.outlier_ratio_threshold << std::endl;
-    std::cout << "moving_average_time " << height_parameter.moving_average_time << std::endl;
   }
   catch (YAML::Exception& e)
   {

--- a/eagleye_rt/src/monitor_node.cpp
+++ b/eagleye_rt/src/monitor_node.cpp
@@ -1119,16 +1119,7 @@ int main(int argc, char** argv)
   node->get_parameter("monitor.th_diff_rad_per_sec",_th_diff_rad_per_sec);
   node->get_parameter("monitor.th_num_continuous_abnormal_yaw_rate",_th_num_continuous_abnormal_yaw_rate);
 
-  std::cout<< "subscribe_rtklib_nav_topic_name "<<subscribe_rtklib_nav_topic_name<<std::endl;
-  std::cout<< "subscribe_gga_topic_name "<<subscribe_gga_topic_name<<std::endl;
-  std::cout<< "print_status "<<_print_status<<std::endl;
-  std::cout<< "log_output_status "<<_log_output_status<<std::endl;
-  std::cout<< "use_compare_yaw_rate "<<_use_compare_yaw_rate<<std::endl;
-  if(_use_compare_yaw_rate) {
-  std::cout<< "comparison_twist_topic_name "<<comparison_twist_topic_name<<std::endl;
-  std::cout<< "th_diff_rad_per_sec "<<_th_diff_rad_per_sec<<std::endl;
-  std::cout<< "th_num_continuous_abnormal_yaw_rate "<<_th_num_continuous_abnormal_yaw_rate<<std::endl;
-  }
+
 
   // // Diagnostic Updater
   double update_time = 1.0 / _update_rate;

--- a/eagleye_rt/src/position_interpolate_node.cpp
+++ b/eagleye_rt/src/position_interpolate_node.cpp
@@ -114,9 +114,6 @@ int main(int argc, char** argv)
     position_interpolate_parameter.stop_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
     position_interpolate_parameter.sync_search_period = conf["/**"]["ros__parameters"]["position_interpolate"]["sync_search_period"].as<double>();
 
-    std::cout << "imu_rate " << position_interpolate_parameter.imu_rate << std::endl;
-    std::cout << "stop_judgment_threshold " << position_interpolate_parameter.stop_judgment_threshold << std::endl;
-    std::cout << "sync_search_period " << position_interpolate_parameter.sync_search_period << std::endl;
   }
   catch (YAML::Exception& e)
   {

--- a/eagleye_rt/src/position_node.cpp
+++ b/eagleye_rt/src/position_node.cpp
@@ -189,27 +189,6 @@ int main(int argc, char** argv)
     position_parameter.gnss_receiving_threshold = conf["/**"]["ros__parameters"]["heading"]["gnss_receiving_threshold"].as<double>();
     position_parameter.outlier_ratio_threshold = conf["/**"]["ros__parameters"]["position"]["outlier_ratio_threshold"].as<double>();
 
-    std::cout<< "use_gnss_mode " << use_gnss_mode << std::endl;
-    std::cout<< "use_can_less_mode " << use_can_less_mode << std::endl;
-
-    std::cout<< "subscribe_rtklib_nav_topic_name " << subscribe_rtklib_nav_topic_name << std::endl;
-
-    std::cout<< "ecef_base_pos_x " << position_parameter.ecef_base_pos_x << std::endl;
-    std::cout<< "ecef_base_pos_y " << position_parameter.ecef_base_pos_y << std::endl;
-    std::cout<< "ecef_base_pos_z " << position_parameter.ecef_base_pos_z << std::endl;
-
-    std::cout<< "tf_gnss_frame/parent " << position_parameter.tf_gnss_parent_frame << std::endl;
-    std::cout<< "tf_gnss_frame/child " << position_parameter.tf_gnss_child_frame << std::endl;
-
-    std::cout << "imu_rate " << position_parameter.imu_rate << std::endl;
-    std::cout << "gnss_rate " << position_parameter.gnss_rate << std::endl;
-    std::cout << "moving_judgment_threshold " << position_parameter.moving_judgment_threshold << std::endl;
-
-    std::cout << "estimated_interval " << position_parameter.estimated_interval << std::endl;
-    std::cout << "update_distance " << position_parameter.update_distance << std::endl;
-    std::cout << "outlier_threshold " << position_parameter.outlier_threshold << std::endl;
-    std::cout << "gnss_receiving_threshold " << position_parameter.gnss_receiving_threshold << std::endl;
-    std::cout << "outlier_ratio_threshold " << position_parameter.outlier_ratio_threshold << std::endl;
   }
   catch (YAML::Exception& e)
   {

--- a/eagleye_rt/src/rolling_node.cpp
+++ b/eagleye_rt/src/rolling_node.cpp
@@ -90,11 +90,6 @@ void setParam(rclcpp::Node::SharedPtr node)
     _rolling_parameter.stop_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
     _rolling_parameter.filter_process_noise = conf["/**"]["ros__parameters"]["rolling"]["filter_process_noise"].as<double>();
     _rolling_parameter.filter_observation_noise = conf["/**"]["ros__parameters"]["rolling"]["filter_observation_noise"].as<double>();
-
-    std::cout<< "use_can_less_mode " << _use_can_less_mode << std::endl;
-    std::cout << "stop_judgment_threshold " << _rolling_parameter.stop_judgment_threshold << std::endl;
-    std::cout << "filter_process_noise " << _rolling_parameter.filter_process_noise << std::endl;
-    std::cout << "filter_observation_noise " << _rolling_parameter.filter_observation_noise << std::endl;
   }
   catch (YAML::Exception& e)
   {

--- a/eagleye_rt/src/rtk_dead_reckoning_node.cpp
+++ b/eagleye_rt/src/rtk_dead_reckoning_node.cpp
@@ -157,17 +157,6 @@ int main(int argc, char** argv)
     rtk_dead_reckoning_parameter.rtk_fix_STD = conf["/**"]["ros__parameters"]["rtk_dead_reckoning"]["rtk_fix_STD"].as<double>();
     rtk_dead_reckoning_parameter.proc_noise = conf["/**"]["ros__parameters"]["rtk_dead_reckoning"]["proc_noise"].as<double>();
 
-    std::cout << "use_gnss_mode " << use_gnss_mode << std::endl;
-
-    std::cout << "ecef_base_pos_x " << rtk_dead_reckoning_parameter.ecef_base_pos_x << std::endl;
-    std::cout << "ecef_base_pos_y " << rtk_dead_reckoning_parameter.ecef_base_pos_y << std::endl;
-    std::cout << "ecef_base_pos_z " << rtk_dead_reckoning_parameter.ecef_base_pos_z << std::endl;
-    std::cout << "use_ecef_base_position " << rtk_dead_reckoning_parameter.use_ecef_base_position << std::endl;
-    std::cout << "tf_gnss_frame/parent " << rtk_dead_reckoning_parameter.tf_gnss_parent_frame << std::endl;
-    std::cout << "tf_gnss_frame/child " << rtk_dead_reckoning_parameter.tf_gnss_child_frame << std::endl;
-    std::cout << "stop_judgment_threshold " << rtk_dead_reckoning_parameter.stop_judgment_threshold << std::endl;
-    std::cout << "rtk_fix_STD " << rtk_dead_reckoning_parameter.rtk_fix_STD << std::endl;
-    std::cout << "proc_noise " << rtk_dead_reckoning_parameter.proc_noise << std::endl;
   }
   catch (YAML::Exception& e)
   {

--- a/eagleye_rt/src/rtk_heading_node.cpp
+++ b/eagleye_rt/src/rtk_heading_node.cpp
@@ -137,22 +137,6 @@ int main(int argc, char** argv)
     heading_parameter.outlier_ratio_threshold = conf["/**"]["ros__parameters"]["rtk_heading"]["outlier_ratio_threshold"].as<double>();
     heading_parameter.curve_judgment_threshold = conf["/**"]["ros__parameters"]["rtk_heading"]["curve_judgment_threshold"].as<double>();
 
-    std::cout<< "use_can_less_mode " << use_can_less_mode << std::endl;
-
-    std::cout<< "subscribe_gga_topic_name " << subscribe_gga_topic_name << std::endl;
-
-    std::cout << "imu_rate " << heading_parameter.imu_rate << std::endl;
-    std::cout << "gnss_rate " << heading_parameter.gnss_rate << std::endl;
-    std::cout << "stop_judgment_threshold " << heading_parameter.stop_judgment_threshold << std::endl;
-    std::cout << "slow_judgment_threshold " << heading_parameter.slow_judgment_threshold << std::endl;
-
-    std::cout << "update_distance " << heading_parameter.update_distance << std::endl;
-    std::cout << "estimated_minimum_interval " << heading_parameter.estimated_minimum_interval << std::endl;
-    std::cout << "estimated_maximum_interval " << heading_parameter.estimated_maximum_interval << std::endl;
-    std::cout << "gnss_receiving_threshold " << heading_parameter.gnss_receiving_threshold << std::endl;
-    std::cout << "outlier_threshold " << heading_parameter.outlier_threshold << std::endl;
-    std::cout << "outlier_ratio_threshold " << heading_parameter.outlier_ratio_threshold << std::endl;
-    std::cout << "curve_judgment_threshold " << heading_parameter.curve_judgment_threshold << std::endl;
   }
   catch (YAML::Exception& e)
   {

--- a/eagleye_rt/src/slip_angle_node.cpp
+++ b/eagleye_rt/src/slip_angle_node.cpp
@@ -111,8 +111,6 @@ int main(int argc, char** argv)
     slip_angle_parameter.stop_judgment_threshold = conf["/**"]["ros__parameters"]["common"]["stop_judgment_threshold"].as<double>();
     slip_angle_parameter.manual_coefficient = conf["/**"]["ros__parameters"]["slip_angle"]["manual_coefficient"].as<double>();
 
-    std::cout << "stop_judgment_threshold " << slip_angle_parameter.stop_judgment_threshold << std::endl;
-    std::cout << "manual_coefficient " << slip_angle_parameter.manual_coefficient << std::endl;
   }
   catch (YAML::Exception& e)
   {

--- a/eagleye_rt/src/slip_coefficient_node.cpp
+++ b/eagleye_rt/src/slip_coefficient_node.cpp
@@ -94,9 +94,6 @@ void imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr msg)
   imu = *msg;
   slip_coefficient_estimate(imu,rtklib_nav,velocity,yaw_rate_offset_stop,yaw_rate_offset_2nd,heading_interpolate_3rd,slip_coefficient_parameter,&slip_coefficient_status,&estimate_coefficient);
 
-  std::cout << "--- \033[1;34m slip_coefficient \033[m ------------------------------"<< std::endl;
-  std::cout<<"\033[1m estimate_coefficient \033[m "<<estimate_coefficient<<std::endl;
-  std::cout << std::endl;
 }
 
 int main(int argc, char** argv)
@@ -126,16 +123,7 @@ int main(int argc, char** argv)
     slip_coefficient_parameter.curve_judgment_threshold = conf["/**"]["ros__parameters"]["slip_coefficient"]["curve_judgment_threshold"].as<double>();
     slip_coefficient_parameter.lever_arm = conf["/**"]["ros__parameters"]["slip_coefficient"]["lever_arm"].as<double>();
 
-    std::cout<< "use_can_less_mode " << use_can_less_mode << std::endl;
 
-    std::cout << "imu_rate " << slip_coefficient_parameter.imu_rate << std::endl;
-    std::cout << "stop_judgment_threshold " << slip_coefficient_parameter.stop_judgment_threshold << std::endl;
-    std::cout << "moving_judgment_threshold " << slip_coefficient_parameter.moving_judgment_threshold << std::endl;
-
-    std::cout << "estimated_minimum_interval " << slip_coefficient_parameter.estimated_minimum_interval << std::endl;
-    std::cout << "estimated_maximum_interval " << slip_coefficient_parameter.estimated_maximum_interval << std::endl;
-    std::cout << "curve_judgment_threshold " << slip_coefficient_parameter.curve_judgment_threshold << std::endl;
-    std::cout << "lever_arm " << slip_coefficient_parameter.lever_arm << std::endl;
   }
   catch (YAML::Exception& e)
   {

--- a/eagleye_rt/src/smoothing_node.cpp
+++ b/eagleye_rt/src/smoothing_node.cpp
@@ -123,18 +123,6 @@ int main(int argc, char** argv)
     smoothing_parameter.moving_average_time = conf["/**"]["ros__parameters"]["smoothing"]["moving_average_time"].as<double>();
     smoothing_parameter.moving_ratio_threshold = conf["/**"]["ros__parameters"]["smoothing"]["moving_ratio_threshold"].as<double>();
 
-    std::cout<< "use_can_less_mode " << use_can_less_mode << std::endl;
-
-    std::cout<< "subscribe_rtklib_nav_topic_name " << subscribe_rtklib_nav_topic_name << std::endl;
-
-    std::cout<< "ecef_base_pos_x " << smoothing_parameter.ecef_base_pos_x << std::endl;
-    std::cout<< "ecef_base_pos_y " << smoothing_parameter.ecef_base_pos_y << std::endl;
-    std::cout<< "ecef_base_pos_z " << smoothing_parameter.ecef_base_pos_z << std::endl;
-
-    std::cout << "gnss_rate " << smoothing_parameter.gnss_rate << std::endl;
-    std::cout << "moving_judgment_threshold " << smoothing_parameter.moving_judgment_threshold << std::endl;
-    std::cout << "moving_average_time " << smoothing_parameter.moving_average_time << std::endl;
-    std::cout << "moving_ratio_threshold " << smoothing_parameter.moving_ratio_threshold << std::endl;
   }
   catch (YAML::Exception& e)
   {

--- a/eagleye_rt/src/tf_converted_imu.cpp
+++ b/eagleye_rt/src/tf_converted_imu.cpp
@@ -89,11 +89,6 @@ TFConvertedIMU::TFConvertedIMU() : Node("eagleye_tf_converted_imu"),
   get_parameter("tf_gnss_frame.parent", tf_base_link_frame_);
   get_parameter("reverse_imu_wz", reverse_imu_wz_);
 
-  std::cout<< "subscribe_imu_topic_name: " << subscribe_imu_topic_name << std::endl;
-  std::cout<< "publish_imu_topic_name: " << publish_imu_topic_name << std::endl;
-  std::cout<< "tf_base_link_frame: " << tf_base_link_frame_ << std::endl;
-  std::cout<< "reverse_imu_wz: " << reverse_imu_wz_ << std::endl;
-
   sub_ =  create_subscription<sensor_msgs::msg::Imu>(subscribe_imu_topic_name, rclcpp::QoS(10), std::bind(&TFConvertedIMU::imu_callback, this, std::placeholders::_1));
   pub_ = create_publisher<sensor_msgs::msg::Imu>("imu/data_tf_converted", rclcpp::QoS(10));
 };
@@ -135,7 +130,6 @@ void TFConvertedIMU::imu_callback(const sensor_msgs::msg::Imu::ConstSharedPtr ms
   } 
   catch (tf2::TransformException& ex)
   {
-    std::cout << "Failed to lookup transform" << std::endl;
     RCLCPP_WARN(rclcpp::get_logger("tf_converted_imu"), "Failed to lookup transform.");
     return;
   }

--- a/eagleye_rt/src/trajectory_node.cpp
+++ b/eagleye_rt/src/trajectory_node.cpp
@@ -189,23 +189,7 @@ int main(int argc, char** argv)
     trajectory_parameter.sensor_noise_yaw_rate = conf["/**"]["ros__parameters"]["trajectory"]["sensor_noise_yaw_rate"].as<double>();
     trajectory_parameter.sensor_bias_noise_yaw_rate = conf["/**"]["ros__parameters"]["trajectory"]["sensor_bias_noise_yaw_rate"].as<double>();
     timer_update_rate = conf["/**"]["ros__parameters"]["trajectory"]["timer_update_rate"].as<double>();
-    // deadlock_threshold = conf["/**"]["ros__parameters"]["trajectory"]["deadlock_threshold"].as<double>();
 
-    std::cout<< "use_can_less_mode " << use_can_less_mode << std::endl;
-
-    std::cout<< "subscribe_twist_topic_name " << subscribe_twist_topic_name << std::endl;
-
-    std::cout << "stop_judgment_threshold " << trajectory_parameter.stop_judgment_threshold << std::endl;
-
-    std::cout << "curve_judgment_threshold " << trajectory_parameter.curve_judgment_threshold << std::endl;
-
-    std::cout << "sensor_noise_velocity " << trajectory_parameter.sensor_noise_velocity << std::endl;
-    std::cout << "sensor_scale_noise_velocity " << trajectory_parameter.sensor_scale_noise_velocity << std::endl;
-    std::cout << "sensor_noise_yaw_rate " << trajectory_parameter.sensor_noise_yaw_rate << std::endl;
-    std::cout << "sensor_bias_noise_yaw_rate " << trajectory_parameter.sensor_bias_noise_yaw_rate << std::endl;
-
-    std::cout << "timer_update_rate " << timer_update_rate << std::endl;
-    // std::cout << "deadlock_threshold " << deadlock_threshold << std::endl;
   }
   catch (YAML::Exception& e)
   {

--- a/eagleye_rt/src/velocity_scale_factor_node.cpp
+++ b/eagleye_rt/src/velocity_scale_factor_node.cpp
@@ -48,6 +48,7 @@ struct VelocityScaleFactorStatus _velocity_scale_factor_status;
 std::string _use_gnss_mode;
 
 bool _is_first_move = false;
+bool _save_log_file = false;
 
 std::string _velocity_scale_factor_save_str;
 double _saved_vsf_estimater_number;
@@ -165,25 +166,27 @@ void load_velocity_scale_factor(std::string txt_path)
 
 void on_timer()
 {
-  if(!_velocity_scale_factor.status.enabled_status && _saved_vsf_estimater_number >= _velocity_scale_factor_status.estimated_number)
+  if(_save_log_file)
   {
+    if(!_velocity_scale_factor.status.enabled_status && _saved_vsf_estimater_number >= _velocity_scale_factor_status.estimated_number)
+    {
+      std::ofstream csv_file(_velocity_scale_factor_save_str);
+      return;
+    }
+
     std::ofstream csv_file(_velocity_scale_factor_save_str);
-    return;
+    csv_file << "estimated_number";
+    csv_file << "\n";
+    csv_file << _velocity_scale_factor_status.estimated_number;
+    csv_file << "\n";
+    csv_file << "velocity_scale_factor";
+    csv_file << "\n";
+    csv_file << _velocity_scale_factor_status.velocity_scale_factor_last;
+    csv_file << "\n";
+    csv_file.close();
+
+    _saved_vsf_estimater_number = _velocity_scale_factor_status.estimated_number;
   }
-
-  std::ofstream csv_file(_velocity_scale_factor_save_str);
-  csv_file << "estimated_number";
-  csv_file << "\n";
-  csv_file << _velocity_scale_factor_status.estimated_number;
-  csv_file << "\n";
-  csv_file << "velocity_scale_factor";
-  csv_file << "\n";
-  csv_file << _velocity_scale_factor_status.velocity_scale_factor_last;
-  csv_file << "\n";
-  csv_file.close();
-
-  _saved_vsf_estimater_number = _velocity_scale_factor_status.estimated_number;
-
   return;
 }
 
@@ -222,28 +225,14 @@ int main(int argc, char** argv)
     node->declare_parameter("velocity_scale_factor.save_velocity_scale_factor",_velocity_scale_factor_parameter.save_velocity_scale_factor);
     node->declare_parameter("velocity_scale_factor.velocity_scale_factor_save_duration",velocity_scale_factor_save_duration);
     node->declare_parameter("velocity_scale_factor.th_velocity_scale_factor_percent",_th_velocity_scale_factor_percent);
+    node->declare_parameter("velocity_scale_factor.save_log_file",_save_log_file);
 
     node->get_parameter("velocity_scale_factor_save_str",_velocity_scale_factor_save_str);
     node->get_parameter("velocity_scale_factor.save_velocity_scale_factor",_velocity_scale_factor_parameter.save_velocity_scale_factor);
     node->get_parameter("velocity_scale_factor.velocity_scale_factor_save_duration",velocity_scale_factor_save_duration);
     node->get_parameter("velocity_scale_factor.th_velocity_scale_factor_percent",_th_velocity_scale_factor_percent);
+    node->get_parameter("velocity_scale_factor.save_log_file",_save_log_file);
 
-    std::cout << "use_gnss_mode " << _use_gnss_mode << std::endl;
-
-    std::cout << "subscribe_twist_topic_name " << subscribe_twist_topic_name << std::endl;
-    std::cout << "subscribe_rtklib_nav_topic_name " << subscribe_rtklib_nav_topic_name << std::endl;
-
-    std::cout << "gnss_rate " << _velocity_scale_factor_parameter.gnss_rate << std::endl;
-    std::cout << "moving_judgment_threshold " << _velocity_scale_factor_parameter.moving_judgment_threshold << std::endl;
-
-    std::cout << "estimated_minimum_interval " << _velocity_scale_factor_parameter.estimated_minimum_interval << std::endl;
-    std::cout << "estimated_maximum_interval " << _velocity_scale_factor_parameter.estimated_maximum_interval << std::endl;
-    std::cout << "gnss_receiving_threshold " << _velocity_scale_factor_parameter.gnss_receiving_threshold << std::endl;
-
-    std::cout<< "velocity_scale_factor_save_str " << _velocity_scale_factor_save_str << std::endl;
-    std::cout<< "save_velocity_scale_factor " << _velocity_scale_factor_parameter.save_velocity_scale_factor << std::endl;
-    std::cout<< "velocity_scale_factor_save_duration " << velocity_scale_factor_save_duration << std::endl;
-    std::cout<< "th_velocity_scale_factor_percent "<<_th_velocity_scale_factor_percent<<std::endl;
   }
   catch (YAML::Exception& e)
   {

--- a/eagleye_rt/src/yaw_rate_offset_node.cpp
+++ b/eagleye_rt/src/yaw_rate_offset_node.cpp
@@ -129,14 +129,7 @@ int main(int argc, char** argv)
         _yaw_rate_offset_parameter.gnss_receiving_threshold = conf["/**"]["ros__parameters"]["yaw_rate_offset"]["gnss_receiving_threshold"].as<double>();
         _yaw_rate_offset_parameter.outlier_threshold = conf["/**"]["ros__parameters"]["yaw_rate_offset_stop"]["outlier_threshold"].as<double>();
 
-        std::cout << "imu_rate " << _yaw_rate_offset_parameter.imu_rate << std::endl;
-        std::cout << "gnss_rate " << _yaw_rate_offset_parameter.gnss_rate << std::endl;
-        std::cout << "moving_judgment_threshold " << _yaw_rate_offset_parameter.moving_judgment_threshold << std::endl;
 
-        std::cout << "estimated_minimum_interval " << _yaw_rate_offset_parameter.estimated_minimum_interval << std::endl;
-        std::cout << "estimated_maximum_interval " << _yaw_rate_offset_parameter.estimated_maximum_interval << std::endl;
-        std::cout << "gnss_receiving_threshold " << _yaw_rate_offset_parameter.gnss_receiving_threshold << std::endl;
-        std::cout << "outlier_threshold " << _yaw_rate_offset_parameter.outlier_threshold << std::endl;
       }
       catch (YAML::Exception& e)
       {
@@ -162,14 +155,6 @@ int main(int argc, char** argv)
         _yaw_rate_offset_parameter.gnss_receiving_threshold = conf["/**"]["ros__parameters"]["yaw_rate_offset"]["gnss_receiving_threshold"].as<double>();
         _yaw_rate_offset_parameter.outlier_threshold = conf["/**"]["ros__parameters"]["yaw_rate_offset_stop"]["outlier_threshold"].as<double>();
 
-        std::cout << "imu_rate " << _yaw_rate_offset_parameter.imu_rate << std::endl;
-        std::cout << "gnss_rate " << _yaw_rate_offset_parameter.gnss_rate << std::endl;
-        std::cout << "moving_judgment_threshold " << _yaw_rate_offset_parameter.moving_judgment_threshold << std::endl;
-
-        std::cout << "estimated_minimum_interval " << _yaw_rate_offset_parameter.estimated_minimum_interval << std::endl;
-        std::cout << "estimated_maximum_interval " << _yaw_rate_offset_parameter.estimated_maximum_interval << std::endl;
-        std::cout << "gnss_receiving_threshold " << _yaw_rate_offset_parameter.gnss_receiving_threshold << std::endl;
-        std::cout << "outlier_threshold " << _yaw_rate_offset_parameter.outlier_threshold << std::endl;
       }
       catch (YAML::Exception& e)
       {

--- a/eagleye_rt/src/yaw_rate_offset_stop_node.cpp
+++ b/eagleye_rt/src/yaw_rate_offset_stop_node.cpp
@@ -88,13 +88,6 @@ int main(int argc, char** argv)
     _yaw_rate_offset_stop_parameter.estimated_interval = conf["/**"]["ros__parameters"]["yaw_rate_offset_stop"]["estimated_interval"].as<double>();
     _yaw_rate_offset_stop_parameter.outlier_threshold = conf["/**"]["ros__parameters"]["yaw_rate_offset_stop"]["outlier_threshold"].as<double>();
 
-    std::cout << "subscribe_twist_topic_name " << subscribe_twist_topic_name << std::endl;
-
-    std::cout << "imu_rate " << _yaw_rate_offset_stop_parameter.imu_rate << std::endl;
-    std::cout << "stop_judgment_threshold " << _yaw_rate_offset_stop_parameter.stop_judgment_threshold << std::endl;
-
-    std::cout << "estimated_minimum_interval " << _yaw_rate_offset_stop_parameter.estimated_interval << std::endl;
-    std::cout << "outlier_threshold " << _yaw_rate_offset_stop_parameter.outlier_threshold << std::endl;
   }
   catch (YAML::Exception& e)
   {


### PR DESCRIPTION
Remove unused/ghost code.
Some callbacks flood with logging messages uncessary IO operation for saving into files so will delete most of those std::cout